### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -465,7 +465,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 join ['http://arxiv.org/abs/', optional_field('eprint')],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             self.format_names('author'),
@@ -485,7 +485,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 optional [join ['http://arxiv.org/abs/', field('eprint')]],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             sentence [self.format_names('author')],

--- a/doc/src/conf.py.in
+++ b/doc/src/conf.py.in
@@ -465,7 +465,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 join ['http://arxiv.org/abs/', optional_field('eprint')],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             self.format_names('author'),
@@ -485,7 +485,7 @@ class ADSArxivStyle(UnsrtStyle):
                 optional_field('adsurl'),
                 optional [join ['http://arxiv.org/abs/', field('eprint')]],
                 optional_field('url'),
-                optional [join ['http://dx.doi.org/', field('doi')]]
+                optional [join ['https://doi.org/', field('doi')]]
         ]
         template = toplevel [
             sentence [self.format_names('author')],


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating the code that generates new DOI-URLs.

Cheers :-)