### PR TITLE
Fix buffer overflow when printing long filenames

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -106,7 +106,7 @@ static void putgauss(float *histo, int width,int height, double x,double y,
 void match_field(fieldstruct *field, fieldstruct *reffield)
 {
     setstruct *refset, *refset2, *set, *fieldset;
-    char  str[128];
+    char  str[MAXCHAR];
     double wcspos[NAXIS],
     angle,scale,dlng,dlat,sig, dlng2,dlat2,sig2, asig,
     dangle,dscale, ddlng,ddlat, shear,sangle, sheartot, sangletot,
@@ -114,7 +114,7 @@ void match_field(fieldstruct *field, fieldstruct *reffield)
     int  i,j,k, lng,lat,
          naxis, nmax;
 
-    sprintf(str, "Matching field %s...", field->rfilename);
+    sprintf(str, "Matching field %.*s ...", MAXCHAR - 20, field->rfilename);
     NFPRINTF(OUTPUT, str);
 
     /* We are going to use FFT routines */


### PR DESCRIPTION
I found this small bug when trying to process a file named `RED-Sci-JMCFARLAND-OMEGACAM-------OCAM_r_SDSS-ESO_CCD_#93-Red---Sci-57305.2731921-d02462770bcb4abe6849353b29b8af22a7d7930e.fits.slist.fits` -- just a tad longer than the current 128 character limit.