### PR TITLE
Add EXTNAME to output .head files

### DIFF
--- a/src/field.c
+++ b/src/field.c
@@ -359,8 +359,6 @@ fieldstruct *load_field(char *filename, int fieldindex, char *hfilename)
             }
             read_samples(set[n], tab, str);
             nsample += set[n]->nsample;
-            //free_tab(set[n]->imatab);
-            //set[n]->imatab = NULL;
             set[n]->setindex = n;
             n++;
         }

--- a/src/field.c
+++ b/src/field.c
@@ -359,8 +359,8 @@ fieldstruct *load_field(char *filename, int fieldindex, char *hfilename)
             }
             read_samples(set[n], tab, str);
             nsample += set[n]->nsample;
-            free_tab(set[n]->imatab);
-            set[n]->imatab = NULL;
+            //free_tab(set[n]->imatab);
+            //set[n]->imatab = NULL;
             set[n]->setindex = n;
             n++;
         }
@@ -551,8 +551,13 @@ void end_field(fieldstruct *field)
     if (field->set)
     {
         for (i=0; i<field->nset; i++)
-            if (field->set[i])
+            if (field->set[i]) {
+                if (field->set[i]->imatab) {
+                    free_tab(field->set[i]->imatab);
+                    field->set[i]->imatab = NULL;
+                }
                 end_set(field->set[i]);
+            }
         free(field->set);
     }
     free(field);

--- a/src/field.c
+++ b/src/field.c
@@ -549,13 +549,8 @@ void end_field(fieldstruct *field)
     if (field->set)
     {
         for (i=0; i<field->nset; i++)
-            if (field->set[i]) {
-                if (field->set[i]->imatab) {
-                    free_tab(field->set[i]->imatab);
-                    field->set[i]->imatab = NULL;
-                }
+            if (field->set[i])
                 end_set(field->set[i]);
-            }
         free(field->set);
     }
     free(field);

--- a/src/header.c
+++ b/src/header.c
@@ -45,7 +45,7 @@
 #include "samples.h"
 
 /*-------------------------- Worthy WCS keywords ----------------------------*/
-char	wcskey[][12] = {"EQUINOX", "RADESYS?", "CTYPE???", "CUNIT???",
+char	wcskey[][12] = {"EXTNAME", "EQUINOX", "RADESYS?", "CTYPE???", "CUNIT???",
 		"CRVAL???", "CRPIX???", "CDELT???", "CD?_?", "PV?_????",
 		"FGROUPNO", "ASTIRMS?", "ASTRRMS?", "ASTINST ",
 		"FLXSCALE", "MAGZEROP", "PHOTIRMS", "PHOTINST", "PHOTLINK",

--- a/src/header.c
+++ b/src/header.c
@@ -162,6 +162,8 @@ int	write_aschead(char *filename, fieldstruct *field)
     {
     tab = new_tab("");
     update_head(tab);
+    addkeywordto_head(tab, "EXTNAME", "Name of this FITS extension");
+    fitswrite(tab->headbuf,"EXTNAME", set[s]->imatab->extname, H_STRING, T_STRING);
     write_wcs(tab, set[s]->wcs);
     switch(prefs.header_type)
       {


### PR DESCRIPTION
It is convenient to have the EXTNAME in the output ASCII header files to make sure we are reading the correct HDU.

I get a line like this in my output .head file,
```
EXTNAME = 'CCD35   '           / TABLE NAME
```

so it looks like my attempt to set the comment part of the FITS header did not work.

As far as I can tell, I'm freeing the header in the right place -- I don't see any complaint about this in valgrind (there are many other memory leaks in my test, so it's hard to tell for sure).
